### PR TITLE
fix: backend builds

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ COPY requirements.txt ./
 
 RUN swupd bundle-add opencv-python
 RUN pip install --upgrade pip
-RUN pip install wheel
+RUN pip install wheel numpy
 RUN pip install -r requirements.txt
 
 CMD ["python", "/workspace/app/main.py"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,6 +12,7 @@ COPY requirements.txt ./
 
 RUN swupd bundle-add opencv-python
 RUN pip install --upgrade pip
+RUN pip install wheel
 RUN pip install -r requirements.txt
 
 CMD ["python", "/workspace/app/main.py"]


### PR DESCRIPTION
Install wheel and numpy, which are now required for some reason (updated base container?)